### PR TITLE
falaise-particleid: new formulae

### DIFF
--- a/Formula/falaise-particleid.rb
+++ b/Formula/falaise-particleid.rb
@@ -1,0 +1,92 @@
+class FalaiseParticleid < Formula
+  desc "Particle ID Plugin Module for Falaise"
+  homepage "https://github.com/xgarrido/ParticleIdentification"
+  head "https://github.com/xgarrido/ParticleIdentification.git"
+
+  patch :DATA
+
+  depends_on "cmake" => :build
+  depends_on "supernemo-dbd/cadfael/falaise"
+
+  def install
+    system "cmake", *std_cmake_args, "."
+    system "make", "install"
+
+  end
+end
+__END__
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 2750da1..9b53f47 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -5,6 +5,8 @@
+ cmake_minimum_required(VERSION 3.3)
+ project(FalaiseParticleIdentificationPlugin)
+ 
++include(GNUInstallDirs)
++
+ # Ensure our code can see the Falaise headers
+ include_directories(${CMAKE_CURRENT_BINARY_DIR})
+ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/source)
+@@ -100,12 +102,14 @@ list(APPEND FalaiseParticleIdentificationPlugin_SOURCES
+ 
+ ###########################################################################################
+ 
++find_package(Falaise REQUIRED)
++
+ # Build a dynamic library from our sources
+ add_library(Falaise_ParticleIdentification SHARED
+   ${FalaiseParticleIdentificationPlugin_HEADERS}
+   ${FalaiseParticleIdentificationPlugin_SOURCES})
+ 
+-target_link_libraries(Falaise_ParticleIdentification Falaise)
++target_link_libraries(Falaise_ParticleIdentification Falaise::FalaiseModule)
+ 
+ # Apple linker requires dynamic lookup of symbols, so we
+ # add link flags on this platform
+@@ -121,10 +125,10 @@ endif()
+ install(TARGETS Falaise_ParticleIdentification DESTINATION ${CMAKE_INSTALL_LIBDIR}/Falaise/modules)
+ 
+ # - Publish headers
+-foreach(_hdrin ${FalaiseParticleIdentificationPlugin_HEADERS})
+-  string(REGEX REPLACE "source/falaise/" "" _hdrout "${_hdrin}")
+-  configure_file(${_hdrin} ${PROJECT_BUILD_INCLUDEDIR}/falaise/${_hdrout} @ONLY)
+-endforeach()
++#foreach(_hdrin ${FalaiseParticleIdentificationPlugin_HEADERS})
++#  string(REGEX REPLACE "source/falaise/" "" _hdrout "${_hdrin}")
++#  configure_file(${_hdrin} ${PROJECT_BUILD_INCLUDEDIR}/falaise/${_hdrout} @ONLY)
++#endforeach()
+ 
+ # Test support:
+ option(FalaiseParticleIdentificationPlugin_ENABLE_TESTING "Build unit testing system for FalaiseParticleIdentification" ON)
+diff --git a/testing/CMakeLists.txt b/testing/CMakeLists.txt
+index 71724e3..a00423a 100644
+--- a/testing/CMakeLists.txt
++++ b/testing/CMakeLists.txt
+@@ -17,7 +17,7 @@ foreach(_testsource ${FalaiseParticleIdentificationPlugin_TESTS})
+   get_filename_component(_testname ${_testsource} NAME_WE)
+   set(_testname "falaiseparticleidentificationplugin-${_testname}")
+   add_executable(${_testname} ${_testsource})
+-  target_link_libraries(${_testname} Falaise_ParticleIdentification)
++  target_link_libraries(${_testname} Falaise::Falaise Falaise_ParticleIdentification)
+   # - On Apple, ensure dynamic_lookup of undefined symbols
+   if(APPLE)
+     set_target_properties(${_testname} PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
+@@ -27,11 +27,11 @@ foreach(_testsource ${FalaiseParticleIdentificationPlugin_TESTS})
+     APPEND PROPERTY ENVIRONMENT ${_trackfit_TEST_ENVIRONMENT}
+     )
+   # - For now, dump them into the testing output directory
+-  set_target_properties(${_testname}
+-    PROPERTIES
+-    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/fltests/modules
+-    ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/fltests/modules
+-    )
++  #set_target_properties(${_testname}
++  #  PROPERTIES
++  #  RUNTIME_OUTPUT_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/fltests/modules
++  #  ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/fltests/modules
++  #  )
+ endforeach()
+ 
+ # end of CMakeLists.txt
+

--- a/Formula/falaise.rb
+++ b/Formula/falaise.rb
@@ -15,6 +15,11 @@ class Falaise < Formula
 
   def install
     ENV.cxx11
+    # Create a base directory for plugins that can be linked into by
+    # plugins
+    falaise_modules = HOMEBREW_PREFIX/"lib/Falaise/modules"
+    falaise_modules.mkpath
+
     mkdir "falaise.build" do
       fl_cmake_args = std_cmake_args
       fl_cmake_args << "-DCMAKE_INSTALL_LIBDIR=lib"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Homebrew tap for SuperNEMO
 Custom Formulae and Commands for SuperNEMO's [cadfaelbrew fork](https://github.com/SuperNEMO-DBD/cadfaelbrew) of
-Linux/Homebrew. Though designed for use with cadfaelbrew, it should work and be compatible with upstream Homebrew (macOS) 
+Linux/Homebrew. Though designed for use with cadfaelbrew, it should work and be compatible with upstream Homebrew (macOS)
 modulo version dependencies on Formulae supplied in this tap. Co-working with Linuxbrew is not yet supported.
 
 # Quickstart
@@ -12,7 +12,7 @@ $ cd cadfaelbrew
 $ ./bin/brew cadfael-bootstrap
 ```
 
-The `cadfael-bootstrap` command will check for system prerequisites, and inform you of any 
+The `cadfael-bootstrap` command will check for system prerequisites, and inform you of any
 missing system packages and how to install these. This step is only done for the following systems:
 
 - RHEL/CentOS/Scientific Linux 6/7
@@ -36,7 +36,7 @@ such as CERN ROOT and Geant4. Should any step fail to complete, see the [Trouble
 for help.
 
 Once installed, no specific environment settings should be required, but you may wish to set
-`PATH`, `MANPATH` and `INFOPATH` so that programs and documentation can be run/read without 
+`PATH`, `MANPATH` and `INFOPATH` so that programs and documentation can be run/read without
 using absolute paths. For example, if you have installed `brew` in `$HOME/cadfaelbrew`, add
 
 ```
@@ -57,7 +57,7 @@ under that directory.
 If you wish to contribute to Falaise development, information is available on the [project page](https://github.com/supernemo-dbd/Falaise).
 
 ## Use with existing Home/Linuxbrew Installations
-If you have an existing Homebrew (macOS) install, this tap may be used directly if you don't have existing brewed versions 
+If you have an existing Homebrew (macOS) install, this tap may be used directly if you don't have existing brewed versions
 of Qt, Boost, CERN ROOT and Geant4. In this case, you simply need to add this tap and then follow the bootstrap/install
 proceedure:
 
@@ -73,7 +73,7 @@ If you see issues in the last two steps, review the [list of Formulae supplied b
 remove any listed here and rerun `brew install falaise`.
 
 Use this tap with an existing Linuxbrew installation is currently not supported as there may be ABI
-incompatibilities between Linuxbrew's install of gcc/glibc/libstdc++ and the requirement for C++11 . On Linux, 
+incompatibilities between Linuxbrew's install of gcc/glibc/libstdc++ and the requirement for C++11 . On Linux,
 it's therefore recommended to use SuperNEMO's fork of brew as described at the start of this section.
 
 # Upgrading
@@ -85,7 +85,7 @@ $ brew update
 $ brew upgrade
 ```
 
-If you have an existing install of `falaise` version 2 or below (run `brew info falaise` to get this information), 
+If you have an existing install of `falaise` version 2 or below (run `brew info falaise` to get this information),
 then the following steps are needed to upgrade to version 3:
 
 ```
@@ -140,7 +140,7 @@ are needed:
 - `libgles2-mesa-dev`
 
 In general, formulae will fail to configure or build should a system requirement be missing.
-We'll make every effort to support other systems, so please [raise an issue](https://github.com/supernemo-dbd/homebrew-cadfael/issues) if you need help here. However, all work in this case will only be on a 
+We'll make every effort to support other systems, so please [raise an issue](https://github.com/supernemo-dbd/homebrew-cadfael/issues) if you need help here. However, all work in this case will only be on a
 best effort basis.
 
 ## Formulae Fail to Install
@@ -180,6 +180,8 @@ versions of dependent packages.
 
 - [Ponder](https://github.com/billyquith/ponder)
   - Note: This replaces the [CAMP]() package
+- [Falaise_ParticleIdentification](https://github.com/xgarrido/ParticleIdentification)
+  - Particle Identification plugin module for Falaise reconstruction/analysis
 
 ## Python
 Installing Falaise will also install (via the ROOT dependency) a brewed copy of Python. This includes


### PR DESCRIPTION
Preliminary Formula for ParticleIdentification module under development
for Falaise's flreconstruct application

- https://github.com/xgarrido/ParticleIdentification

The formula is 'HEAD' only as the is no stable tag yet, though the
module is ready to try out. A patch is supplied to get it building
under brew/Falaise 3.

The Falaise formula is updated to create the `lib/Falaise/modules`
directory as a full rather than softlinked path into the falaise
formula. This is a test of allowing modules to be installed
independently of Falaise. Though functional for installing Falaise
and ParticleIdentification, it cannot run the PID module without
pointing the flreconstruct script to it. This is due to flreconstruct
only considering the directory under its Cellar location. This
requires further review.

- [x] Have you followed the [guidelines for contributing](https://github.com/supernemo-dbd/homebrew-cadfael/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/supernemo-dbd/homebrew-cadfael/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
