### PR TITLE
Import GSL and bump revisions of users

### DIFF
--- a/Aliases/bayeux@3
+++ b/Aliases/bayeux@3
@@ -1,0 +1,1 @@
+../Formula/bayeux.rb

--- a/Formula/bayeux.rb
+++ b/Formula/bayeux.rb
@@ -1,11 +1,12 @@
 class Bayeux < Formula
-  desc "Bayeux Library"
-  homepage ""
-  version "3.0.0"
+  desc "Core C++ Framework Library for SuperNEMO Experiment"
+  homepage "https://github.com/supernemo-dbd/bayeux"
   url "https://files.warwick.ac.uk/supernemo/files/Cadfael/distfiles/Bayeux-3.0.0.tar.bz2"
   sha256 "f0f01465ad20e51a05ca889cfdc52c12d0a2cf16d70dd6f4e04551c652ce967e"
   revision 1
-  
+
+  option "with-devtools", "Build debug tools for Bayeux developers"
+
   needs :cxx11
 
   depends_on "cmake" => :build
@@ -21,8 +22,6 @@ class Bayeux < Formula
   depends_on "supernemo-dbd/cadfael/root6"
   depends_on "supernemo-dbd/cadfael/qt5-base"
 
-  option "with-devtools", "Build debug tools for Bayeux developers"
-
   def install
     ENV.cxx11
     mkdir "bayeux.build" do
@@ -31,7 +30,7 @@ class Bayeux < Formula
       bx_cmake_args << "-DBAYEUX_CXX_STANDARD=11"
       bx_cmake_args << "-DBAYEUX_COMPILER_ERROR_ON_WARNING=OFF"
       bx_cmake_args << "-DBAYEUX_WITH_QT_GUI=ON"
-      bx_cmake_args << "-DBAYEUX_WITH_DEVELOPER_TOOLS=OFF" unless build.with? "devtools"
+      bx_cmake_args << "-DBAYEUX_WITH_DEVELOPER_TOOLS=OFF" if build.without? "devtools"
       system "cmake", "..", *bx_cmake_args
       system "make", "install"
     end
@@ -41,4 +40,3 @@ class Bayeux < Formula
     system "#{bin}/bxg4_production", "--help"
   end
 end
-

--- a/Formula/bayeux.rb
+++ b/Formula/bayeux.rb
@@ -4,15 +4,16 @@ class Bayeux < Formula
   version "3.0.0"
   url "https://files.warwick.ac.uk/supernemo/files/Cadfael/distfiles/Bayeux-3.0.0.tar.bz2"
   sha256 "f0f01465ad20e51a05ca889cfdc52c12d0a2cf16d70dd6f4e04551c652ce967e"
+  revision 1
+  
+  needs :cxx11
 
   depends_on "cmake" => :build
-  depends_on "supernemo-dbd/cadfael/doxygen" => :build
-
-  depends_on "gsl"
+  depends_on "icu4c" => "c++11"
   depends_on "readline"
 
-  needs :cxx11
-  depends_on "icu4c" => "c++11"
+  depends_on "supernemo-dbd/cadfael/doxygen" => :build
+  depends_on "supernemo-dbd/cadfael/gsl"
   depends_on "supernemo-dbd/cadfael/boost" => ["c++11", "with-icu4c"]
   depends_on "supernemo-dbd/cadfael/camp" => "c++11"
   depends_on "supernemo-dbd/cadfael/clhep" => "c++11"

--- a/Formula/bayeux@2.rb
+++ b/Formula/bayeux@2.rb
@@ -1,12 +1,13 @@
 class BayeuxAT2 < Formula
-  desc "Bayeux Library"
-  homepage ""
-  version "2.2.0"
+  desc "Core C++ Framework Library for the SuperNEMO Experiment"
+  homepage "https://github.com/supernemo-dbd/bayeux"
   url "https://files.warwick.ac.uk/supernemo/files/Cadfael/distfiles/Bayeux-2.2.0.tar.bz2"
   sha256 "fe03bfb6563af9aaef0da97c270863f14bd82d5427bdb4eb860edbf4ffb964b1"
   revision 1
 
   keg_only "Conflicts with newer production versions"
+
+  option "with-devtools", "Build debug tools for Bayeux developers"
 
   needs :cxx11
 
@@ -22,8 +23,6 @@ class BayeuxAT2 < Formula
   depends_on "supernemo-dbd/cadfael/geant4" => "c++11"
   depends_on "supernemo-dbd/cadfael/root6"
 
-  option "with-devtools", "Build debug tools for Bayeux developers"
-
   def install
     ENV.cxx11
     mkdir "bayeux.build" do
@@ -31,7 +30,7 @@ class BayeuxAT2 < Formula
       bx_cmake_args << "-DCMAKE_INSTALL_LIBDIR=lib"
       bx_cmake_args << "-DBAYEUX_CXX_STANDARD=11"
       bx_cmake_args << "-DBAYEUX_COMPILER_ERROR_ON_WARNING=OFF"
-      bx_cmake_args << "-DBAYEUX_WITH_DEVELOPER_TOOLS=OFF" unless build.with? "devtools"
+      bx_cmake_args << "-DBAYEUX_WITH_DEVELOPER_TOOLS=OFF" if build.without? "devtools"
       system "cmake", "..", *bx_cmake_args
       system "make", "install"
     end
@@ -41,4 +40,3 @@ class BayeuxAT2 < Formula
     system "false"
   end
 end
-

--- a/Formula/bayeux@2.rb
+++ b/Formula/bayeux@2.rb
@@ -4,17 +4,18 @@ class BayeuxAT2 < Formula
   version "2.2.0"
   url "https://files.warwick.ac.uk/supernemo/files/Cadfael/distfiles/Bayeux-2.2.0.tar.bz2"
   sha256 "fe03bfb6563af9aaef0da97c270863f14bd82d5427bdb4eb860edbf4ffb964b1"
+  revision 1
 
   keg_only "Conflicts with newer production versions"
 
-  depends_on "cmake" => :build
-  depends_on "supernemo-dbd/cadfael/doxygen" => :build
-
-  depends_on "gsl"
-  depends_on "readline"
-
   needs :cxx11
+
+  depends_on "cmake" => :build
+  depends_on "readline"
   depends_on "icu4c" => "c++11"
+
+  depends_on "supernemo-dbd/cadfael/gsl"
+  depends_on "supernemo-dbd/cadfael/doxygen" => :build
   depends_on "supernemo-dbd/cadfael/boost" => ["c++11", "with-icu4c"]
   depends_on "supernemo-dbd/cadfael/camp" => "c++11"
   depends_on "supernemo-dbd/cadfael/clhep" => "c++11"

--- a/Formula/falaise.rb
+++ b/Formula/falaise.rb
@@ -3,8 +3,9 @@ class Falaise < Formula
   homepage "https://supernemo-dbd.github.io"
   url "https://files.warwick.ac.uk/supernemo/files/Cadfael/distfiles/Falaise-3.0.0.tar.bz2"
   sha256 "2cba670ce626887270af5f6e98106c6f07c5f3214fb281af5ef7894442d544d7"
-  head "https://github.com/SuperNEMO-DBD/Falaise.git", :branch => "develop"
   revision 1
+
+  head "https://github.com/SuperNEMO-DBD/Falaise.git", :branch => "develop"
 
   depends_on "cmake" => :build
   depends_on "supernemo-dbd/cadfael/doxygen" => :build

--- a/Formula/falaise.rb
+++ b/Formula/falaise.rb
@@ -4,6 +4,7 @@ class Falaise < Formula
   url "https://files.warwick.ac.uk/supernemo/files/Cadfael/distfiles/Falaise-3.0.0.tar.bz2"
   sha256 "2cba670ce626887270af5f6e98106c6f07c5f3214fb281af5ef7894442d544d7"
   head "https://github.com/SuperNEMO-DBD/Falaise.git", :branch => "develop"
+  revision 1
 
   depends_on "cmake" => :build
   depends_on "supernemo-dbd/cadfael/doxygen" => :build

--- a/Formula/falaise@2.rb
+++ b/Formula/falaise@2.rb
@@ -4,6 +4,7 @@ class FalaiseAT2 < Formula
   url "https://files.warwick.ac.uk/supernemo/files/Cadfael/distfiles/Falaise-2.2.0.tar.bz2"
   version "2.2.0"
   sha256 "b702ed4d1874894435fbc56df4c95573cb7c07f49526706e3c0ee8b50b8c52e1"
+  revision 1
 
   keg_only "Conflicts with newer production versions"
 

--- a/Formula/gsl.rb
+++ b/Formula/gsl.rb
@@ -1,0 +1,25 @@
+class Gsl < Formula
+  desc "Numerical library for C and C++"
+  homepage "https://www.gnu.org/software/gsl/"
+  url "https://ftp.gnu.org/gnu/gsl/gsl-2.4.tar.gz"
+  mirror "https://ftpmirror.gnu.org/gsl/gsl-2.4.tar.gz"
+  sha256 "4d46d07b946e7b31c19bbf33dda6204d7bedc2f5462a1bae1d4013426cd1ce9b"
+
+  bottle do
+    cellar :any
+    sha256 "ea19659efea6c85dfda0b42468fd2d4bc980ec2689a07fa3506ea2a5fc9a9c89" => :sierra
+    sha256 "0e58f3748624d439a7152557518e389827a8a38dfa7ea486625d38e86291f9b2" => :el_capitan
+    sha256 "e8f5a126564d238ed734d3f069b183304ec1a707473cbce7fdde512122ccf3fb" => :yosemite
+    sha256 "cc9c752252817f13c74b9d9178e2f5f9f5db4358abd9b8e932624502429f480d" => :x86_64_linux
+  end
+
+  def install
+    system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"
+    system "make" # A GNU tool which doesn't support just make install! Shameful!
+    system "make", "install"
+  end
+
+  test do
+    system bin/"gsl-randist", "0", "20", "cauchy", "30"
+  end
+end

--- a/Formula/root5.rb
+++ b/Formula/root5.rb
@@ -7,7 +7,7 @@ class Root5 < Formula
      url "https://root.cern.ch/download/root_v#{version}.source.tar.gz"
      mirror "http://ftp.riken.jp/pub/ROOT/root_v#{version}.source.tar.gz"
    end
-   revision 1
+   revision 2
 
    head do
      url "https://github.com/root-mirror/root.git", :branch => "v5-34-00-patches"
@@ -19,8 +19,9 @@ class Root5 < Formula
    option :cxx11
 
    depends_on "openssl"
-   depends_on "gsl" => :recommended
    depends_on :python => :recommended
+   
+   depends_on "supernemo-dbd/cadfael/gsl" => :recommended
 
    def install
      # When building the head, temp patch for ROOT-8032

--- a/Formula/root6.rb
+++ b/Formula/root6.rb
@@ -6,9 +6,9 @@ class Root6 < Formula
   version "6.08.06"
   sha256 "ea31b047ba6fc04b0b312667349eaf1498a254ccacd212144f15ffcb3f5c0592"
   head "http://root.cern.ch/git/root.git"
+  revision 1
 
   depends_on "cmake" => :build
-  depends_on "gsl" => :recommended
   depends_on "openssl" => :optional
   depends_on "sqlite" => :recommended
   depends_on :python => :recommended
@@ -17,6 +17,8 @@ class Root6 < Formula
 
   # For XML on Linux
   depends_on "libxml2" if OS.linux?
+  
+  depends_on "supernemo-dbd/cadfael/gsl" => :recommended
 
   needs :cxx11
 

--- a/README.md
+++ b/README.md
@@ -211,13 +211,14 @@ Installing the ``falaise`` formula will install the core SuperNEMO software pack
 plus their upstream dependencies:
 
 - [Boost](http://www.boost.org)
-- [ROOT](https://root.cern.ch)
 - [CAMP](https://github.com/tegesoft/camp)
 - [CLHEP](http://proj-clhep.web.cern.ch/proj-clhep/)
-- [XercesC](http://xerces.apache.org/xerces-c/)
-- [Geant4](http://geant4.cern.ch)
 - [Doxygen](http://www.stack.nl/~dimitri/doxygen/)
+- [GSL](http://https://www.gnu.org/software/gsl/)
+- [Geant4](http://geant4.cern.ch)
 - [Qt5](http://doc.qt.io/qt-5/)
+- [ROOT](https://root.cern.ch)
+- [XercesC](http://xerces.apache.org/xerces-c/)
 
 ## Development
 Several additional Formulae are provided which are not installed by default. These are intended for


### PR DESCRIPTION
Fixes #22 

Changes to GSL soversion by upstream caused issues with users of the package, as reported in #22.

Import GSL formula @2.4 into this tap to provide stability as it is a major dependency of SuperNEMO software. Bump revision numbers of using packages to ensure these will be reinstalled on upgrade.

Update supplied formulae list in README.