### PR TITLE
Add curl dependency to Xerces-c

### DIFF
--- a/Formula/bayeux.rb
+++ b/Formula/bayeux.rb
@@ -3,7 +3,7 @@ class Bayeux < Formula
   homepage "https://github.com/supernemo-dbd/bayeux"
   url "https://files.warwick.ac.uk/supernemo/files/Cadfael/distfiles/Bayeux-3.0.0.tar.bz2"
   sha256 "f0f01465ad20e51a05ca889cfdc52c12d0a2cf16d70dd6f4e04551c652ce967e"
-  revision 1
+  revision 2
 
   option "with-devtools", "Build debug tools for Bayeux developers"
 

--- a/Formula/falaise.rb
+++ b/Formula/falaise.rb
@@ -3,7 +3,7 @@ class Falaise < Formula
   homepage "https://supernemo-dbd.github.io"
   url "https://files.warwick.ac.uk/supernemo/files/Cadfael/distfiles/Falaise-3.0.0.tar.bz2"
   sha256 "2cba670ce626887270af5f6e98106c6f07c5f3214fb281af5ef7894442d544d7"
-  revision 1
+  revision 2
 
   head "https://github.com/SuperNEMO-DBD/Falaise.git", :branch => "develop"
 

--- a/Formula/geant4.rb
+++ b/Formula/geant4.rb
@@ -1,7 +1,7 @@
 class Geant4 < Formula
   desc "C++ toolkit for simulating the passage of particles through matter"
   homepage "http://geant4.cern.ch"
-  revision 4
+  revision 5
 
   stable do
     url "http://geant4.cern.ch/support/source/geant4.9.6.p04.tar.gz"

--- a/Formula/xerces-c.rb
+++ b/Formula/xerces-c.rb
@@ -3,6 +3,9 @@ class XercesC < Formula
   homepage "https://xerces.apache.org/xerces-c/"
   url "https://www.apache.org/dyn/closer.cgi?path=xerces/c/3/sources/xerces-c-3.1.4.tar.gz"
   sha256 "c98eedac4cf8a73b09366ad349cb3ef30640e7a3089d360d40a3dde93f66ecf6"
+  revision 1
+
+  depends_on "curl" unless OS.mac?
 
   option :cxx11
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/supernemo-dbd/homebrew-cadfael/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/supernemo-dbd/homebrew-cadfael/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
-----

Fixes #26 

Xerces-c uses curl, so add explicit dependence on Linux only.

