### PR TITLE
root6: disable fortran

### DIFF
--- a/Formula/root6.rb
+++ b/Formula/root6.rb
@@ -5,7 +5,7 @@ class Root6 < Formula
   mirror "https://fossies.org/linux/misc/root_v6.08.06.source.tar.gz"
   version "6.08.06"
   sha256 "ea31b047ba6fc04b0b312667349eaf1498a254ccacd212144f15ffcb3f5c0592"
-  revision 3
+  revision 4
 
   head "http://root.cern.ch/git/root.git"
 
@@ -49,6 +49,7 @@ class Root6 < Formula
         "-Ddavix=OFF",
         "-Ddcache=OFF",
         "-Dfitsio=OFF",
+        "-Dfortran=OFF",
         "-Dgfal=OFF",
         "-Dglite=OFF",
         "-Dgviz=OFF",


### PR DESCRIPTION
Presence of old fortran compilers on Linux may cause auto activation
of support in Root6. If the compiler is old, errors are likely to
occur as reported in Issue #29.

As SuperNEMO do not require use of Fortran, explicitly disable support
for it in Root6.

- [x] Have you followed the [guidelines for contributing](https://github.com/supernemo-dbd/homebrew-cadfael/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/supernemo-dbd/homebrew-cadfael/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
-----
