### PR TITLE
xrootd: New formula

### DIFF
--- a/Formula/xrootd.rb
+++ b/Formula/xrootd.rb
@@ -1,0 +1,26 @@
+class Xrootd < Formula
+  desc "High performance, scalable, fault-tolerant access to data"
+  homepage "http://xrootd.org"
+  url "http://xrootd.org/download/v4.6.1/xrootd-4.6.1.tar.gz"
+  sha256 "0261ce760e8788f85d68918d7702ae30ec677a8f331dae14adc979b4cc7badf5"
+  head "https://github.com/xrootd/xrootd.git"
+
+  depends_on "cmake" => :build
+  depends_on "libxml2"
+  depends_on "openssl"
+  depends_on "readline"
+
+  needs :cxx11
+
+  def install
+    ENV.cxx11
+    mkdir "build" do
+      system "cmake", "..", "-DCMAKE_INSTALL_LIBDIR=#{lib}", "-DENABLE_FUSE=OFF", "-DENABLE_KRB5=OFF", *std_cmake_args
+      system "make", "install"
+    end
+  end
+
+  test do
+    system "#{bin}/xrootd", "-H"
+  end
+end


### PR DESCRIPTION
To support file transfer in ROOT. Using version 4.6.1 to match
version on server. Bump as compatibility allows.

New formula needed to support #51 

- [x] Have you followed the [guidelines for contributing](https://github.com/supernemo-dbd/homebrew-cadfael/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/supernemo-dbd/homebrew-cadfael/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
-----


