### PR TITLE
qt5-base: no my/postgresql

### DIFF
--- a/Formula/qt5-base.rb
+++ b/Formula/qt5-base.rb
@@ -43,6 +43,8 @@ class Qt5Base < Formula
       -pkg-config
       -no-avx
       -no-avx2
+      -no-sql-mysql
+      -no-sql-psql
       -c++std c++14
     ]
 


### PR DESCRIPTION
Qt's configure system can pick up system installs of Mysql and postgres,
resulting in link time errors. As we do not require these plugins for
SuperNEMO, explicitly disable them.

- [x] Have you followed the [guidelines for contributing](https://github.com/supernemo-dbd/homebrew-cadfael/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/supernemo-dbd/homebrew-cadfael/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
