### PR TITLE
Fixes for audit warnings

### DIFF
--- a/Formula/bayeux.rb
+++ b/Formula/bayeux.rb
@@ -9,19 +9,19 @@ class Bayeux < Formula
 
   option "with-devtools", "Build debug tools for Bayeux developers"
 
-  needs :cxx11
-
   depends_on "cmake" => :build
   depends_on "doxygen" => :build
   depends_on "icu4c"
   depends_on "readline"
-  depends_on "supernemo-dbd/cadfael/gsl"
   depends_on "supernemo-dbd/cadfael/boost"
   depends_on "supernemo-dbd/cadfael/camp"
   depends_on "supernemo-dbd/cadfael/clhep"
   depends_on "supernemo-dbd/cadfael/geant4"
-  depends_on "supernemo-dbd/cadfael/root6"
+  depends_on "supernemo-dbd/cadfael/gsl"
   depends_on "supernemo-dbd/cadfael/qt5-base"
+  depends_on "supernemo-dbd/cadfael/root6"
+
+  needs :cxx11
 
   def install
     ENV.cxx11

--- a/Formula/bayeux@2.rb
+++ b/Formula/bayeux@2.rb
@@ -9,18 +9,18 @@ class BayeuxAT2 < Formula
 
   option "with-devtools", "Build debug tools for Bayeux developers"
 
-  needs :cxx11
-
   depends_on "cmake" => :build
   depends_on "doxygen" => :build
-  depends_on "readline"
   depends_on "icu4c"
-  depends_on "supernemo-dbd/cadfael/gsl"
+  depends_on "readline"
   depends_on "supernemo-dbd/cadfael/boost"
   depends_on "supernemo-dbd/cadfael/camp"
   depends_on "supernemo-dbd/cadfael/clhep"
   depends_on "supernemo-dbd/cadfael/geant4"
+  depends_on "supernemo-dbd/cadfael/gsl"
   depends_on "supernemo-dbd/cadfael/root6"
+
+  needs :cxx11
 
   def install
     ENV.cxx11

--- a/Formula/boost.rb
+++ b/Formula/boost.rb
@@ -5,9 +5,9 @@ class Boost < Formula
   sha256 "beae2529f759f6b3bf3f4969a19c2e9d6f0c503edcb2de4a61d1428519fcb3b0"
   revision 4
 
-  needs :cxx11
-
   depends_on "icu4c"
+
+  needs :cxx11
 
   unless OS.mac?
     depends_on "bzip2"

--- a/Formula/camp.rb
+++ b/Formula/camp.rb
@@ -5,11 +5,11 @@ class Camp < Formula
   version "0.8.0"
   revision 1
 
-  needs :cxx11
-
   depends_on "cmake" => :build
   depends_on "doxygen" => [:optional, :build]
   depends_on "supernemo-dbd/cadfael/boost"
+
+  needs :cxx11
 
   def install
     ENV.cxx11

--- a/Formula/clhep.rb
+++ b/Formula/clhep.rb
@@ -16,9 +16,9 @@ class Clhep < Formula
     sha256 "66272ae3100d3aec096b1298e1e24ec25b80e4dac28332b45ec3284023592963"
   end
 
-  needs :cxx11
-
   depends_on "cmake" => :build
+
+  needs :cxx11
 
   def install
     ENV.cxx11

--- a/Formula/falaise@2.rb
+++ b/Formula/falaise@2.rb
@@ -9,11 +9,11 @@ class FalaiseAT2 < Formula
 
   depends_on "cmake" => :build
   depends_on "doxygen" => :build
+  depends_on "supernemo-dbd/cadfael/bayeux@2"
 
   needs :cxx11
 
   # Bayeux dependency pulls in all additional deps of Falaise at present
-  depends_on "supernemo-dbd/cadfael/bayeux@2"
 
   def install
     ENV.cxx11

--- a/Formula/falaise@3.1.rb
+++ b/Formula/falaise@3.1.rb
@@ -4,20 +4,20 @@ class FalaiseAT31 < Formula
   url "https://github.com/SuperNEMO-DBD/Falaise/archive/Falaise-3.1.1.tar.gz"
   sha256 "5befdf043186860dd4d8c7a07a3ebfb201999e27c8ab0b006849ef83bfc3474c"
 
-  patch do
-   # Addresses ROOT 6.12.04 generate_dictionary change
-   url "https://github.com/SuperNEMO-DBD/Falaise/pull/76.patch?full_index=1"
-   sha256 "a5deadda12c9a46008631e6e001b55aef0920884636787f4774b29a5981f24cf"
-  end
+  keg_only :versioned_formula
 
   depends_on "cmake" => :build
   depends_on "doxygen" => :build
-  # Bayeux dependency pulls in all additional deps of Falaise at present
   depends_on "supernemo-dbd/cadfael/bayeux"
 
-  needs :cxx11
+  patch do
+    # Addresses ROOT 6.12.04 generate_dictionary change
+    url "https://github.com/SuperNEMO-DBD/Falaise/pull/76.patch?full_index=1"
+    sha256 "a5deadda12c9a46008631e6e001b55aef0920884636787f4774b29a5981f24cf"
+  end
+  # Bayeux dependency pulls in all additional deps of Falaise at present
 
-  keg_only :versioned_formula
+  needs :cxx11
 
   def install
     ENV.cxx11

--- a/Formula/geant4.rb
+++ b/Formula/geant4.rb
@@ -35,15 +35,14 @@ class Geant4 < Formula
     sha256 "702fb0f7a78d4bdf1e3f14508de26e4db5e2df6a21a8066a92b7e6ce21f4eb2d"
   end
 
-  needs :cxx11
+  option "with-notimeout", "Set notimeout in installing data"
 
   depends_on "cmake" => :build
   depends_on "expat" if OS.linux?
-
   depends_on "supernemo-dbd/cadfael/clhep"
   depends_on "supernemo-dbd/cadfael/xerces-c"
 
-  option "with-notimeout", "Set notimeout in installing data"
+  needs :cxx11
 
   def install
     ENV.cxx11

--- a/Formula/ninja.rb
+++ b/Formula/ninja.rb
@@ -5,7 +5,7 @@ class Ninja < Formula
   sha256 "86b8700c3d0880c2b44c2ff67ce42774aaf8c28cbf57725cb881569288c1c6f4"
   head "https://github.com/ninja-build/ninja.git"
 
-  depends_on "python@2" => :build unless OS.mac? 
+  depends_on "python@2" => :build unless OS.mac?
 
   def install
     system "python", "configure.py", "--bootstrap"
@@ -26,4 +26,3 @@ class Ninja < Formula
     system bin/"ninja", "-t", "targets"
   end
 end
-

--- a/Formula/ptd2root.rb
+++ b/Formula/ptd2root.rb
@@ -3,8 +3,8 @@ class Ptd2root < Formula
   homepage "https://github.com/SuperNEMO-DBD/PTD2Root"
   url "https://github.com/SuperNEMO-DBD/PTD2Root/archive/v1.0.0.tar.gz"
   sha256 "a469ce8708188c2a6601b80e9cafb7d6fea4cf0f1e88e527d77fec13c37ceed4"
-  head "https://github.com/SuperNEMO-DBD/PTD2Root.git", :branch => "develop"
   revision 1
+  head "https://github.com/SuperNEMO-DBD/PTD2Root.git", :branch => "develop"
 
   depends_on "cmake" => :build
   depends_on "supernemo-dbd/cadfael/falaise"

--- a/Formula/qt5-base.rb
+++ b/Formula/qt5-base.rb
@@ -6,8 +6,8 @@ class Qt5Base < Formula
 
   keg_only "qt5 is very picky about install locations, so keep it isolated"
 
-  depends_on :xcode => :build if OS.mac?
   depends_on "pkg-config" => :build
+  depends_on :xcode => :build if OS.mac?
 
   unless OS.mac?
     depends_on "icu4c"
@@ -26,7 +26,9 @@ class Qt5Base < Formula
 
   def install
     # Patch for https://bugreports.qt.io/browse/QTBUG-67545
-    inreplace "./src/platformsupport/fontdatabases/mac/qfontengine_coretext.mm", "return QFixed::QFixed(int(CTFontGetUnitsPerEm(ctfont)));", "return QFixed(int(CTFontGetUnitsPerEm(ctfont)));"
+    inreplace "./src/platformsupport/fontdatabases/mac/qfontengine_coretext.mm",
+      "return QFixed::QFixed(int(CTFontGetUnitsPerEm(ctfont)));",
+      "return QFixed(int(CTFontGetUnitsPerEm(ctfont)));"
 
     args = %W[
       -verbose
@@ -85,7 +87,7 @@ class Qt5Base < Formula
   def caveats; <<~EOS
     We agreed to the Qt opensource license for you.
     If this is unacceptable you should uninstall.
-    EOS
+  EOS
   end
 
   test do
@@ -113,8 +115,8 @@ class Qt5Base < Formula
 
     system bin/"qmake", testpath/"hello.pro"
     system "make"
-    assert File.exist?("hello")
-    assert File.exist?("main.o")
+    assert_predicate testpath/"hello", :exist?
+    assert_predicate testpath/"main.o", :exist?
     system "./hello"
   end
 end

--- a/Formula/root6.rb
+++ b/Formula/root6.rb
@@ -20,6 +20,8 @@ class Root6 < Formula
 
   conflicts_with "root", :because => "SuperNEMO requires custom root build"
 
+  skip_clean "bin"
+
   needs :cxx11
 
   def install
@@ -140,7 +142,7 @@ class Root6 < Formula
       pushd $(brew --prefix root6) >/dev/null; . libexec/thisroot.sh; popd >/dev/null
     For csh/tcsh users:
       source `brew --prefix root6`/libexec/thisroot.csh
-    EOS
+  EOS
   end
 
   test do
@@ -157,7 +159,7 @@ class Root6 < Formula
     assert_equal "\nProcessing test.C...\nHello, world!\n",
                  shell_output("/bin/bash test.bash")
 
-    ENV["PYTHONPATH"] = #{lib}/"root"
+    ENV["PYTHONPATH"] = "#{lib}/root"
     system "python2", "-c", "'import ROOT'"
   end
 end

--- a/Formula/xerces-c.rb
+++ b/Formula/xerces-c.rb
@@ -1,7 +1,7 @@
 class XercesC < Formula
   desc "Validating XML parser"
   homepage "https://xerces.apache.org/xerces-c/"
-  url "http://archive.apache.org/dist/xerces/c/3/sources/xerces-c-3.1.4.tar.gz"
+  url "https://archive.apache.org/dist/xerces/c/3/sources/xerces-c-3.1.4.tar.gz"
   sha256 "c98eedac4cf8a73b09366ad349cb3ef30640e7a3089d360d40a3dde93f66ecf6"
   revision 4
 


### PR DESCRIPTION
Formula updated with recommendations from output of "brew audit
--strict". A few items have been left:

- gcc49 use of "ecj". Now deprecated with move to gcc@7.
- igprof libunwind dependency. Under development
- xrootd Python link paths. To be investigated

- [x] Have you followed the [guidelines for contributing](https://github.com/supernemo-dbd/homebrew-cadfael/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/supernemo-dbd/homebrew-cadfael/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

All audit checks pass with the exception of those noted. No changes to formula versions or builds otherwise.
