### PR TITLE
root6: Fixes for macOS/devel

### DIFF
--- a/Formula/root6.rb
+++ b/Formula/root6.rb
@@ -1,7 +1,7 @@
 class Root6 < Formula
   desc "CERN C++ Data Analysis and Persistency Libraries"
   homepage "http://root.cern.ch"
-  revision 1
+  revision 2
   head "http://root.cern.ch/git/root.git"
 
   stable do
@@ -38,6 +38,8 @@ class Root6 < Formula
     ENV.delete("SDKROOT") if DevelopmentTools.clang_build_version >= 900
     args = *std_cmake_args
     args << "-DCMAKE_INSTALL_ELISPDIR=#{elisp}"
+    # Avoid macOS case issues from "root/ROOT" paths
+    args << "-DCMAKE_INSTALL_INCLUDEDIR=include/root6"
 
     # Disable everything that might be ON by default
     args += %w[
@@ -98,7 +100,7 @@ class Root6 < Formula
 
     # Only fail on missing for non-devel builds due to
     # https://github.com/root-project/root/pull/2972
-    args += "-Dfail-on-missing=ON" unless build.devel?
+    args << "-Dfail-on-missing=ON" unless build.devel?
 
     # Python requires a bit of finessing
     ENV.prepend_path "PATH", Formula["python@2"].opt_libexec/"bin"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/supernemo-dbd/homebrew-cadfael/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/supernemo-dbd/homebrew-cadfael/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Builds root6 with modified include path to avoid case sensitivity issues on macOS. Bumps revision to ensure we get consistent behaviour across all platforms, and unity between stable and devel.

Fixes #64 
