### PR TITLE
xrootd: explicitly depend on Python

### DIFF
--- a/Formula/xrootd.rb
+++ b/Formula/xrootd.rb
@@ -8,6 +8,7 @@ class Xrootd < Formula
   depends_on "cmake" => :build
   depends_on "libxml2"
   depends_on "openssl"
+  depends_on "python@2"
   depends_on "readline"
 
   needs :cxx11


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/supernemo-dbd/homebrew-cadfael/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/supernemo-dbd/homebrew-cadfael/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Xrootd will always build python (and we'll want that feature), but Homebrew now strips the system python include path. Add the explicit dependency to `python@2`, with `2` choosen for commonality with ROOT's python requirement.