### PR TITLE
gcc49: remove obsolete fails_with

### DIFF
--- a/Formula/gcc49.rb
+++ b/Formula/gcc49.rb
@@ -50,8 +50,6 @@ class Gcc49 < Formula
 
   cxxstdlib_check :skip
 
-  fails_with :gcc_4_0
-
   patch do
     url "https://gist.githubusercontent.com/sjackman/34fa1081982bda781862/raw/738349d49f4f094cced7cfe287cdcdfcd7207265/52fd2e1.diff"
     sha256 "360dc5061909bae0096d86546e53eae971755661da386b403f836eb70fa335f1"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/supernemo-dbd/homebrew-cadfael/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/supernemo-dbd/homebrew-cadfael/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Remove `gcc_4_0` failure which is no longer supported in Homebrew. Unlikely to affect SuperNEMO since our oldest platform has GCC 4.4 as the system compiler.