### PR TITLE
gcc49: remove deprecated macos 64bit

### DIFF
--- a/Formula/gcc49.rb
+++ b/Formula/gcc49.rb
@@ -1,18 +1,6 @@
 class Gcc49 < Formula
   def arch
-    if Hardware::CPU.type == :intel
-      if MacOS.prefer_64_bit?
-        "x86_64"
-      else
-        "i686"
-      end
-    elsif Hardware::CPU.type == :ppc
-      if MacOS.prefer_64_bit?
-        "powerpc64"
-      else
-        "powerpc"
-      end
-    end
+    "x86_64"
   end
 
   def osmajor


### PR DESCRIPTION
No change to behaviour, simply prevents warning on newer Homebrews
on macOS.

- [x] Have you followed the [guidelines for contributing](https://github.com/supernemo-dbd/homebrew-cadfael/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/supernemo-dbd/homebrew-cadfael/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----