### PR TITLE
qt5-base: Don't use new-ish kernels

### DIFF
--- a/Formula/qt5-base.rb
+++ b/Formula/qt5-base.rb
@@ -71,7 +71,14 @@ class Qt5Base < Formula
       args << "-R#{HOMEBREW_PREFIX}/lib"
       # If we end up depending on any keg_only Formulae, add extra
       # -R lines for each of them below here.
+
+      # Portable binaries for kernels < 3.17 cannot be created without 
+      # these flags. In particular, they are required to allow modern
+      # containers to run on older systems.
+      args << "-no-feature-renameat2"
+      args << "-no-feature-getentropy"
     end
+
     system "./configure", *args
 
     # Cannot parellize build os OSX


### PR DESCRIPTION
Running an ubuntu 18 container on a CentOS 7 system warned about
libQt5Core.so not being found. Binaries were checked for correct
RUNPATHs and found to be o.k. Other Qt libraries were found and loaded
without issue. Probable cause found to be Qt encoding kernel ABI into
library (and thus container shared kernel not supporting this) per
report here:

https://github.com/NixOS/nixpkgs/pull/40577

Use same set of arguments in that patch to build binaries with
compatibility for older kernels.

- [x] Have you followed the [guidelines for contributing](https://github.com/supernemo-dbd/homebrew-cadfael/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/supernemo-dbd/homebrew-cadfael/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
