### PR TITLE
Remove no-longer support `needs: cxx11`

### DIFF
--- a/Formula/bayeux.rb
+++ b/Formula/bayeux.rb
@@ -21,8 +21,6 @@ class Bayeux < Formula
   depends_on "supernemo-dbd/cadfael/qt5-base"
   depends_on "supernemo-dbd/cadfael/root6"
 
-  needs :cxx11
-
   def install
     ENV.cxx11
     mkdir "bayeux.build" do

--- a/Formula/bayeux@2.rb
+++ b/Formula/bayeux@2.rb
@@ -20,8 +20,6 @@ class BayeuxAT2 < Formula
   depends_on "supernemo-dbd/cadfael/gsl"
   depends_on "supernemo-dbd/cadfael/root6"
 
-  needs :cxx11
-
   def install
     ENV.cxx11
     mkdir "bayeux.build" do

--- a/Formula/falaise.rb
+++ b/Formula/falaise.rb
@@ -10,8 +10,6 @@ class Falaise < Formula
   # Bayeux dependency pulls in all additional deps of Falaise at present
   depends_on "supernemo-dbd/cadfael/bayeux"
 
-  needs :cxx11
-
   def install
     ENV.cxx11
     mkdir "falaise.build" do

--- a/Formula/falaise@2.rb
+++ b/Formula/falaise@2.rb
@@ -9,11 +9,8 @@ class FalaiseAT2 < Formula
 
   depends_on "cmake" => :build
   depends_on "doxygen" => :build
-  depends_on "supernemo-dbd/cadfael/bayeux@2"
-
-  needs :cxx11
-
   # Bayeux dependency pulls in all additional deps of Falaise at present
+  depends_on "supernemo-dbd/cadfael/bayeux@2"
 
   def install
     ENV.cxx11

--- a/Formula/falaise@3.1.rb
+++ b/Formula/falaise@3.1.rb
@@ -17,8 +17,6 @@ class FalaiseAT31 < Formula
   end
   # Bayeux dependency pulls in all additional deps of Falaise at present
 
-  needs :cxx11
-
   def install
     ENV.cxx11
     mkdir "falaise.build" do

--- a/Formula/falaise@3.2.rb
+++ b/Formula/falaise@3.2.rb
@@ -11,8 +11,6 @@ class FalaiseAT32 < Formula
   # Bayeux dependency pulls in all additional deps of Falaise at present
   depends_on "supernemo-dbd/cadfael/bayeux"
 
-  needs :cxx11
-
   def install
     ENV.cxx11
     mkdir "falaise.build" do

--- a/Formula/ponder.rb
+++ b/Formula/ponder.rb
@@ -9,6 +9,7 @@ class Ponder < Formula
   depends_on "doxygen" => :build
 
   def install
+    ENV.cxx11
     mkdir "brew-ponder-build" do
       system "cmake", "..", *std_cmake_args
       system "make", "install"

--- a/Formula/ptd2root.rb
+++ b/Formula/ptd2root.rb
@@ -10,6 +10,7 @@ class Ptd2root < Formula
   depends_on "supernemo-dbd/cadfael/falaise"
 
   def install
+    ENV.cxx11
     system "cmake", ".", *std_cmake_args
     system "make", "install"
   end


### PR DESCRIPTION
Additional fixes on top of PR #72

- [x] Have you followed the [guidelines for contributing](https://github.com/supernemo-dbd/homebrew-cadfael/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/supernemo-dbd/homebrew-cadfael/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
