### PR TITLE
gcc49: Remove disabled prefer_64_bit on macOS

### DIFF
--- a/Formula/gcc49.rb
+++ b/Formula/gcc49.rb
@@ -157,7 +157,7 @@ class Gcc49 < Formula
       args << "--with-ecj-jar=#{Formula["ecj"].opt_share}/java/ecj.jar"
     end
 
-    if build.without?("multilib") || !MacOS.prefer_64_bit?
+    if build.without?("multilib")
       args << "--disable-multilib"
     else
       args << "--enable-multilib"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/supernemo-dbd/homebrew-cadfael/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/supernemo-dbd/homebrew-cadfael/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
