### PR TITLE
gcc49: Additional macOS prefer_64_bit removal

### DIFF
--- a/Formula/gcc49.rb
+++ b/Formula/gcc49.rb
@@ -59,9 +59,7 @@ class Gcc49 < Formula
 
   # enabling multilib on a host that can't run 64-bit results in build failures
   if OS.mac?
-    option "without-multilib", "Build without multilib support" if MacOS.prefer_64_bit?
-  else
-    option "with-multilib", "Build with multilib support"
+    option "without-multilib", "Build without multilib support"
   end
 
   if OS.linux?


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/supernemo-dbd/homebrew-cadfael/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/supernemo-dbd/homebrew-cadfael/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
