### PR TITLE
Extract expat, fontconfig from core

### DIFF
--- a/Aliases/expat
+++ b/Aliases/expat
@@ -1,0 +1,1 @@
+../Formula/expat@2.2.6.rb

--- a/Aliases/fontconfig
+++ b/Aliases/fontconfig
@@ -1,0 +1,1 @@
+../Formula/fontconfig@2.13.1.rb

--- a/Formula/expat@2.2.6.rb
+++ b/Formula/expat@2.2.6.rb
@@ -1,0 +1,64 @@
+class ExpatAT226 < Formula
+  desc "XML 1.0 parser"
+  homepage "https://libexpat.github.io/"
+  url "https://github.com/libexpat/libexpat/releases/download/R_2_2_6/expat-2.2.6.tar.bz2"
+  sha256 "17b43c2716d521369f82fc2dc70f359860e90fa440bea65b3b85f0b246ea81f2"
+
+  head do
+    url "https://github.com/libexpat/libexpat.git"
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+    depends_on "docbook2x" => :build
+    depends_on "libtool" => :build
+  end
+
+  keg_only :provided_by_macos
+
+  def install
+    cd "expat" if build.head?
+    system "autoreconf", "-fiv" if build.head?
+    args = ["--prefix=#{prefix}", "--mandir=#{man}"]
+    args << "--without-docbook"
+    system "./configure", *args
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<~EOS
+      #include <stdio.h>
+      #include "expat.h"
+
+      static void XMLCALL my_StartElementHandler(
+        void *userdata,
+        const XML_Char *name,
+        const XML_Char **atts)
+      {
+        printf("tag:%s|", name);
+      }
+
+      static void XMLCALL my_CharacterDataHandler(
+        void *userdata,
+        const XML_Char *s,
+        int len)
+      {
+        printf("data:%.*s|", len, s);
+      }
+
+      int main()
+      {
+        static const char str[] = "<str>Hello, world!</str>";
+        int result;
+
+        XML_Parser parser = XML_ParserCreate("utf-8");
+        XML_SetElementHandler(parser, my_StartElementHandler, NULL);
+        XML_SetCharacterDataHandler(parser, my_CharacterDataHandler);
+        result = XML_Parse(parser, str, sizeof(str), 1);
+        XML_ParserFree(parser);
+
+        return result;
+      }
+    EOS
+    system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lexpat", "-o", "test"
+    assert_equal "tag:str|data:Hello, world!|", shell_output("./test")
+  end
+end

--- a/Formula/fontconfig@2.13.1.rb
+++ b/Formula/fontconfig@2.13.1.rb
@@ -1,0 +1,49 @@
+class FontconfigAT2131 < Formula
+  desc "XML-based font configuration API for X Windows"
+  homepage "https://wiki.freedesktop.org/www/Software/fontconfig/"
+  url "https://www.freedesktop.org/software/fontconfig/release/fontconfig-2.13.1.tar.bz2"
+  sha256 "f655dd2a986d7aa97e052261b36aa67b0a64989496361eca8d604e6414006741"
+
+  head do
+    url "https://anongit.freedesktop.org/git/fontconfig", :using => :git
+
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+    depends_on "libtool" => :build
+  end
+
+  depends_on "pkg-config" => :build
+  depends_on "freetype"
+
+  def install
+    font_dirs = %w[
+      /System/Library/Fonts
+      /Library/Fonts
+      ~/Library/Fonts
+    ]
+
+    if MacOS.version >= :sierra
+      font_dirs << Dir["/System/Library/Assets/com_apple_MobileAsset_Font*"].max
+    end
+
+    system "autoreconf", "-iv" if build.head?
+    system "./configure", "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--disable-docs",
+                          "--enable-static",
+                          "--with-add-fonts=#{font_dirs.join(",")}",
+                          "--prefix=#{prefix}",
+                          "--localstatedir=#{var}",
+                          "--sysconfdir=#{etc}"
+    system "make", "install", "RUN_FC_CACHE_TEST=false"
+  end
+
+  def post_install
+    ohai "Regenerating font cache, this may take a while"
+    system "#{bin}/fc-cache", "-frv"
+  end
+
+  test do
+    system "#{bin}/fc-list"
+  end
+end


### PR DESCRIPTION
With Homebrew removing options, we cannot use or update options in Formulae that need them.

Both expat and fontconfig can fail to build on CentOS due to use of system docbook. Extract them from core into our tap using `brew extract` and alias so they will be preferred providing our tap is pinned.

This addresses reports in #69 and #71 

- [x] Have you followed the [guidelines for contributing](https://github.com/supernemo-dbd/homebrew-cadfael/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/supernemo-dbd/homebrew-cadfael/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
