### PR TITLE
Revert automatic deletion of trailing whitespaces

### DIFF
--- a/Formula/clhep.rb
+++ b/Formula/clhep.rb
@@ -53,14 +53,14 @@ __END__
 --- a/CLHEP/Matrix/src/Vector.cc.orig
 +++ b/CLHEP/Matrix/src/Vector.cc
 @@ -114,9 +114,9 @@ HepVector::HepVector(const HepMatrix &hm1)
-
+ 
  // trivial methods
-
--inline int HepVector::num_row() const {return nrow;}
--inline int HepVector::num_size() const {return nrow;}
+ 
+-inline int HepVector::num_row() const {return nrow;} 
+-inline int HepVector::num_size() const {return nrow;} 
 -inline int HepVector::num_col() const { return 1; }
 +int HepVector::num_row() const {return nrow;}
 +int HepVector::num_size() const {return nrow;}
 +int HepVector::num_col() const { return 1; }
-
+ 
  // operator()


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/supernemo-dbd/homebrew-cadfael/blob/master/CONTRIBUTING.md)?
- [X ] Have you checked that there aren't other open [pull requests](https://github.com/supernemo-dbd/homebrew-cadfael/pulls) for the same formula update/change?
- [ X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
